### PR TITLE
Bump up version of notebook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ matplotlib==3.0.0
 mistune==0.8.3
 nbconvert==5.4.0
 nbformat==4.4.0
-notebook==5.7.2
+notebook==5.7.8
 numpy==1.15.1
 pandas==0.23.4
 pandocfilters==1.4.2


### PR DESCRIPTION
# Bump up version of `notebook`

A security vulnerability was recently found (as of Apr 1, 2019) for `notebook<5.7.8`. This PR bumps up the requirement to match the patch release released to fix this vulnerability.